### PR TITLE
fix: remove fix-permissions run on CONDA_DIR

### DIFF
--- a/images/base/dockerfile
+++ b/images/base/dockerfile
@@ -13,8 +13,10 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 USER root
 # Install all OS dependencies for notebook server that starts but lacks all
 # features (e.g., download as all possible file formats)
+
 RUN mkdir /var/lib/dpkg && \
     touch /var/lib/dpkg/status
+
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update --yes && \
     # - apt-get upgrade is run to patch known vulnerabilities in apt-get packages as
@@ -25,7 +27,9 @@ RUN apt-get update --yes && \
     bzip2 \
     ca-certificates \
     locales \
+    # - fd to improve chown performance with CHOWN_HOME_EXCLUDE option
     sudo \
+    fd-find \
     # - tini is installed as a helpful container entrypoint that reaps zombie
     #   processes and such of the actual executable we want to start, see
     #   https://github.com/krallin/tini#why-tini for details.
@@ -33,12 +37,10 @@ RUN apt-get update --yes && \
     wget && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
-    locale-gen
-
-# Install fd to improve chown performance with CHOWN_HOME_EXCLUDE option
-RUN wget https://github.com/sharkdp/fd/releases/download/v8.6.0/fd_8.6.0_amd64.deb && \
-    dpkg -i fd_8.6.0_amd64.deb && \
-    rm fd_8.6.0_amd64.deb
+    locale-gen && \
+    # symlink fd to fdfind since fd is already used by another package
+    # https://github.com/sharkdp/fd#on-ubuntu
+    ln -s $(which fdfind) /usr/bin/fd
 
 # Configure environment
 ENV CONDA_DIR=/opt/conda \
@@ -69,7 +71,7 @@ RUN echo "auth requisite pam_deny.so" >> /etc/pam.d/su && \
     sed -i.bak -e 's/^%sudo/#%sudo/' /etc/sudoers && \
     useradd -l -m -s /bin/bash -N -u "${NB_UID}" "${NB_USER}" && \
     mkdir -p "${CONDA_DIR}" && \
-    chown "${NB_USER}:${NB_GID}" "${CONDA_DIR}" && \
+    chown -R "${NB_USER}:${NB_GID}" "${CONDA_DIR}" && \
     chmod g+w /etc/passwd && \
     fix-permissions "${HOME}" && \
     fix-permissions "${CONDA_DIR}"
@@ -79,8 +81,46 @@ USER ${NB_UID}
 ARG PYTHON_VERSION=3.10
 # Setup work directory for backward-compatibility
 RUN mkdir "/home/${NB_USER}/work" && \
-    fix-permissions "/home/${NB_USER}" && \
-    fix-permissions "${CONDA_DIR}"
+    fix-permissions "/home/${NB_USER}"
+
+# Download and install Micromamba, and initialize Conda prefix.
+#   <https://github.com/mamba-org/mamba#micromamba>
+#   Similar projects using Micromamba:
+#     - Micromamba-Docker: <https://github.com/mamba-org/micromamba-docker>
+#     - repo2docker: <https://github.com/jupyterhub/repo2docker>
+# Install Python, Mamba and jupyter_core
+# Cleanup temporary files and remove Micromamba
+# Correct permissions
+# Do all this in a single RUN command to avoid duplicating all of the
+# files across image layers when the permissions change
+COPY --chown="${NB_UID}:${NB_GID}" initial-condarc "${CONDA_DIR}/.condarc"
+WORKDIR /tmp
+RUN set -x && \
+    arch=$(uname -m) && \
+    if [ "${arch}" = "x86_64" ]; then \
+        # Should be simpler, see <https://github.com/mamba-org/mamba/issues/1437>
+        arch="64"; \
+    fi && \
+    wget -qO /tmp/micromamba.tar.bz2 \
+        "https://micromamba.snakepit.net/api/micromamba/linux-${arch}/latest" && \
+    tar -xvjf /tmp/micromamba.tar.bz2 --strip-components=1 bin/micromamba && \
+    rm /tmp/micromamba.tar.bz2 && \
+    PYTHON_SPECIFIER="python=${PYTHON_VERSION}" && \
+    if [[ "${PYTHON_VERSION}" == "default" ]]; then PYTHON_SPECIFIER="python"; fi && \
+    # Install the packages
+    ./micromamba install \
+        --root-prefix="${CONDA_DIR}" \
+        --prefix="${CONDA_DIR}" \
+        --yes \
+        "${PYTHON_SPECIFIER}" \
+        'mamba' \
+        'jupyter_core' && \
+    rm micromamba && \
+    # Pin major.minor version of python
+    mamba list python | grep '^python ' | tr -s ' ' | cut -d ' ' -f 1,2 >> "${CONDA_DIR}/conda-meta/pinned" && \
+    mamba clean --all -f -y && \
+    fix-permissions "${CONDA_DIR}" && \
+    fix-permissions "/home/${NB_USER}"
 
 # Configure container startup
 ENTRYPOINT ["tini", "-g", "--"]

--- a/images/base/fix-permissions.sh
+++ b/images/base/fix-permissions.sh
@@ -18,18 +18,19 @@
 set -e
 
 for d in "$@"; do
-    find "${d}" \
-        ! \( \
-            -group "${NB_GID}" \
-            -a -perm -g+rwX \
-        \) \
-        -exec chgrp "${NB_GID}" -- {} \+ \
-        -exec chmod g+rwX -- {} \+
-    # setuid, setgid *on directories only*
-    find "${d}" \
-        \( \
-            -type d \
-            -a ! -perm -6000 \
-        \) \
-        -exec chmod +6000 -- {} \+
+	find "${d}" \
+		! \( \
+		-group "${NB_GID}" \
+		-a -perm -g+rwX \
+		\) \
+		-exec chgrp "${NB_GID}" -- {} \+ \
+		-exec chmod g+rwX -- {} \+
+	# setuid, setgid *on directories only*
+	find "${d}" \
+		\( \
+		-type d \
+		-a ! -perm -6000 \
+		\) \
+		-exec chmod +6000 -- {} \+
 done
+

--- a/images/base/initial-condarc
+++ b/images/base/initial-condarc
@@ -1,0 +1,6 @@
+# Conda configuration see https://conda.io/projects/conda/en/latest/configuration.html
+
+auto_update_conda: false
+show_channel_urls: true
+channels:
+  - conda-forge


### PR DESCRIPTION
Add additional `INSTALLER` as environment variable to use mamba/conda. Add `initial-condarc` to set up conda configuration.

We could use an if statement to check if the image uses mamba or conda, and then install required packages, but this would introduce a lot more complexity to the Dockerfile. Instead, we could trade some disk space for simplicity.